### PR TITLE
fix for a dead link

### DIFF
--- a/_posts/2015-02-16-how-to-help.md
+++ b/_posts/2015-02-16-how-to-help.md
@@ -4,6 +4,6 @@ title:  "How to Help"
 date:   2015-02-16 00:00:00
 categories: cbpp update
 ---
-+ TONS of people have been asking about how to help! Be sure to check out our [github repos](https://github.com/CBPP/cbppsubmit) bugs or suggestions via the 'issues' button.
++ TONS of people have been asking about how to help! Be sure to check out our [github repos](https://github.com/CBPP) for bugs or suggestions via the 'issues' button.
 + Git officionados should obviously feel welcome to clone the repo and have a look around.
 And obviously be sure to submit a pull request if you have any fixes.


### PR DESCRIPTION
https://github.com/CBPP/cbppsubmit does not exist anymore.
Changed to https://github.com/CBPP.
Also added "for".
